### PR TITLE
[Fix] - 상세 페이지 추천 영화 카드리스트 화면 크기 조정

### DIFF
--- a/style/similarMoviesStyle.css
+++ b/style/similarMoviesStyle.css
@@ -6,6 +6,10 @@
   min-width: 400px;
 }
 
+.similarMovies > h2 {
+  color: white;
+}
+
 .similarMovieCard {
   border-radius: 10px;
   overflow: hidden;

--- a/style/similarMoviesStyle.css
+++ b/style/similarMoviesStyle.css
@@ -1,9 +1,9 @@
 .similarMovies {
-  /* border: solid red; */
+  border: solid beige;
   font-size: 30px;
   font-weight: bold;
-  /* background-color: #ffffff; */
-  background-color: #000000;
+  width: 40%;
+  min-width: 400px;
 }
 
 .similarMovieCard {
@@ -15,8 +15,7 @@
 
 .similarMovieCard:hover {
   transform: translateY(-10px);
-  /* background-color: #000; */
-  background-color: #ddd8d8a3;
+  background-color: #000;
   transition: transform 0.5s ease;
   transition: 500ms linear;
   box-shadow: 0 0 20px rgba(255, 255, 255, 0.2);


### PR DESCRIPTION
### 상세 페이지 추천 영화 카드 리스트 화면 크기 조정

- 영화 세부 내용의 조정에 따른 상세 페이지 추천 영화 카드 리스트 또한 동일하게 화면 크기 조정
- 좌측 영화 제목 및 개요, border와 색상 일치화

### 1920 x 1080 기준 전체 화면 이미지

![제목 없음](https://github.com/eliotjang/Movolleh-Movie-Website/assets/37320831/488a2c59-2902-4b98-9d36-3c71735f1606)

### 1920 x 1080 기준 약 60% 화면 이미지

![화면 캡처 2024-05-03 225622](https://github.com/eliotjang/Movolleh-Movie-Website/assets/37320831/7d67a5b1-d6fa-485e-b43b-45e17ca914c6)

### 1920 x 1080 기준 약 30% 이미지

![화면 캡처 2024-05-03 225645](https://github.com/eliotjang/Movolleh-Movie-Website/assets/37320831/03ba0314-8229-49c4-afb6-bd2913b7c1a7)
