### PR TITLE
[Bugfix] - 팀 소개 이미지 변경

### DIFF
--- a/style/index.css
+++ b/style/index.css
@@ -86,7 +86,7 @@ h2 {
 
 .teamIntroducePoster {
   background-size: cover;
-  background-image: url(https://blog.kakaocdn.net/dn/leYIi/btsHbORECO0/5gndv3E7Setlcbb2ZI9PGK/img.png);
+  background-image: url(https://blog.kakaocdn.net/dn/VDtcn/btsHctGiYzb/7PyiGZM64KdTWZhQFoKcoK/img.png);
   object-fit: cover;
   width: 100vw;
   height: 30vw;


### PR DESCRIPTION
### 이미지 색감 수정

problem : 이미지 보정 시 사용했던 검은색이 본래 포스터와 서로 다른 문제
solve : 본래 포스터에 사용되었던 색으로 변경

### 이미지 클리핑 수정

problem : 이미지 클리핑 공정 상의 문제로 불필요한 테두리가 남아 있던 문제
solve : 재 클리핑을 통한 테두리 삭제 및 위치 이동으로 인한 부자연스러운 경계 삭제

### 이미지 비교

![image](https://github.com/eliotjang/Movolleh-Movie-Website/assets/167046779/e1697022-543f-4958-a081-efea05047c61)
