### PR TITLE
61-fix-영화제목-및-추천영화-border-크기-및-높이-일치화

### DIFF
--- a/style/index.css
+++ b/style/index.css
@@ -103,7 +103,6 @@ h2 {
   padding-top: 12.5vw;
 }
 .introduceText {
-  /* width: 200px; */
   font-size: calc(0.1rem + 1.5vw);
   text-align: center;
   top: 35vw;

--- a/style/similarMoviesStyle.css
+++ b/style/similarMoviesStyle.css
@@ -1,5 +1,5 @@
 .similarMovies {
-  border: solid beige;
+  border: 2px double;
   font-size: 30px;
   font-weight: bold;
   width: 40%;
@@ -8,6 +8,7 @@
 
 .similarMovies > h2 {
   color: white;
+  margin-top: 54px;
 }
 
 .similarMovieCard {


### PR DESCRIPTION
### 영화 제목, 추천영화 border 일치화

일괄 2px double;으로 통일

### 영화 제목과 추천 영화 제목 높이 일치화

상세페이지 상의 영화 제목과 우측 추천영화 "비슷한 영화 더 볼래?"의 높이 통일

![image](https://github.com/eliotjang/Movolleh-Movie-Website/assets/167046779/2ff5e0e8-856f-4dd3-bbe3-70ea25ec6fc8)