### PR TITLE
62 fix 제목 폰트 크기 및 색상 일치화

### DIFF
--- a/style/movieDetail.css
+++ b/style/movieDetail.css
@@ -105,6 +105,8 @@ h2 {
   font-size: 25px;
   margin-left: 5px;
   margin-bottom: 15px;
+  color: white;
+  font-weight: bold;
 }
 
 .director {
@@ -153,16 +155,20 @@ li {
   word-break: break-all;
   line-height: 110%;
   color: beige;
-  font-weight: bold;
+  font-weight: bolder;
   text-align: center;
+  font-size: 15.5px;
 }
+
 .character {
   margin-top: 20px;
   max-width: 130px;
-  color: rgb(238, 238, 137);
+  color: white;
   word-break: break-all;
   line-height: 110%;
   text-align: center;
+  font-weight: bold;
+  font-size: 14px;
 }
 
 .similarMovies {

--- a/style/movieDetail.css
+++ b/style/movieDetail.css
@@ -103,7 +103,7 @@ h2 {
 }
 .directorActorJob {
   font-size: 25px;
-  margin-left: 5px;
+  margin-left: 20px;
   margin-bottom: 15px;
   color: white;
   font-weight: bold;

--- a/style/review.css
+++ b/style/review.css
@@ -3,6 +3,8 @@
   text-align: left;
   font-size: 25px;
   margin-bottom: 25px;
+  color: white;
+  font-weight: bold;
 }
 
 /* 테이블 기본설정 */


### PR DESCRIPTION
### 제목 폰트 크기 및 색상 일치화

- 영화 제목 및 추천 영화(비슷한 영화 더 볼래?)의 크기를 통일해보았으나 한글/알파벳의 시각적 차이로 한글이 항상 작아보이는 문제 발생
- 영화 제목을 중요도가 가장 높은 정보로 간주하여 가장 크게 유지하고, 감독/출연진 및 리뷰의 크기는 동일하게 유지
- 감독/출연진의 위치와 리뷰볼래?의 위치를 동일하게 수정

![image](https://github.com/eliotjang/Movolleh-Movie-Website/assets/167046779/334d7ecc-b85f-4bde-bd53-ac795ba097d7)


### 폰트는 흰색으로 통일

상세 내용을 흰 색으로 통일했더니 너무 단조로워 보이고, 백-흑의 대비로 인해 눈이 피로해진다는 느낌을 받음
또한 두 색을 사용했을 때 보다 포커싱이 떨어지는 문제를 발견

- 큰 제목은 흰색, 세부 내용은 베이지로 통일하되 감독/배우의 배역은 흰색으로 표기
  - 유저 입장에서 해당 배우가 어떤 배역을 맡았는지 인지하기 쉬워질 것