### PR TITLE
[BugFix] - 상세 페이지 감독 및 출연진에서 감독과 출연진 순서가 섞이는 현상

### DIFF
--- a/src/crewDetail/crewCard.js
+++ b/src/crewDetail/crewCard.js
@@ -10,12 +10,30 @@ export const introduceCard = async () => {
       return v; // 제작진(crew) 중에서 감독을 찾아서 할당
     }
   });
-  for (let i = 0; i < 5; i++) {
-    if (director.length > i) {
-      introduceDirector(director[i]); // 1번함수 실행
+
+  // 감독 출력
+  let directornum = 0;
+  let directorlist = [];
+  for (let i = 0; i < director.length; i++) {
+    for (let directorbreak in director) {
+      if (typeof directorbreak.job == "undefined") {
+        break;
+      }
+      if (directorbreak.job !== "director") {
+        break;
+      }
     }
-    introduceCast(cast[i]); // 2번함수 실행
+    introduceDirector(director[i]);
+    directorlist.push(director[i].name);
   }
+  directornum = directorlist.length; // 감독 수에 따라 배우 수를 출력해야하므로 감독 수를 기억해둔다
+
+  // 배우 출력
+  let castnum = 0;
+  do {
+    introduceCast(cast[castnum]);
+    castnum = castnum + 1;
+  } while (castnum < 6 - directornum); // 감독 수에 따라 출력될 배우 수를 조정해준다
 };
 
 //

--- a/src/crewDetail/crewCard.js
+++ b/src/crewDetail/crewCard.js
@@ -12,28 +12,28 @@ export const introduceCard = async () => {
   });
 
   // 감독 출력
-  let directornum = 0;
-  let directorlist = [];
+  let directorNumber = 0;
+  let directorList = [];
   for (let i = 0; i < director.length; i++) {
-    for (let directorbreak in director) {
-      if (typeof directorbreak.job == "undefined") {
+    for (let directorBreak in director) {
+      if (typeof directorBreak.job == "undefined") {
         break;
       }
-      if (directorbreak.job !== "director") {
+      if (directorBreak.job !== "director") {
         break;
       }
     }
     introduceDirector(director[i]);
-    directorlist.push(director[i].name);
+    directorList.push(director[i].name);
   }
-  directornum = directorlist.length; // 감독 수에 따라 배우 수를 출력해야하므로 감독 수를 기억해둔다
+  directorNumber = directorList.length; // 감독 수에 따라 배우 수를 출력해야하므로 감독 수를 기억해둔다
 
   // 배우 출력
-  let castnum = 0;
+  let castNumber = 0;
   do {
-    introduceCast(cast[castnum]);
-    castnum = castnum + 1;
-  } while (castnum < 6 - directornum); // 감독 수에 따라 출력될 배우 수를 조정해준다
+    introduceCast(cast[castNumber]);
+    castNumber = castNumber + 1;
+  } while (castNumber < 6 - directorNumber); // 감독 수에 따라 출력될 배우 수를 조정해준다
 };
 
 //


### PR DESCRIPTION
### 발견된 문제점

상세 페이지 감독 및 출연진에서 감독이 2명 이상인 경우 감독과 출연진 순서가 뒤섞이는 현상

### 해결 방법

감독과 출연진을 한꺼번에 출력하도록 되어있는 코드를 따로따로 작성하여
감독 정보를 모두 출력한 이후 출연진의 정보를 출력하도록 변경

### 그 외 추가사항

감독의 job이 director가 맞는지 검증하는 코드 추가
감독의 수가 늘어나는 만큼 출연진의 수가 조정되어 출력 되도록 하는 코드 추가

### 코드수정 이후 모습

![image](https://github.com/eliotjang/Movolleh-Movie-Website/assets/166963977/e154188b-3970-4401-addf-2bc4dfaf8aaa)
