### PR TITLE
[Bugfix] - 리뷰 수정 시 비밀번호 예외 처리 alert 창 2번 출력

### DIFF
--- a/src/review/review.js
+++ b/src/review/review.js
@@ -46,7 +46,6 @@ const editReview = () => {
         console.log(`${index}번 삭제`);
 
         editLocalStorage(index, editText, checkWriter, editRatingStar, editReviewPassword);
-        location.reload(true);
       });
     });
   });
@@ -187,6 +186,7 @@ let editLocalStorage = (index, editText, checkWriter, editRatingStar, editReview
       }
     }
   }
+  location.reload(true);
 };
 
 // 영화 id를 확인하여 해당 영화의 리뷰를 출력


### PR DESCRIPTION
### 리뷰 수정 시 비밀번호 예외 처리 alert 창 2번 출력

- `location.reload(true);` 함수를 `editReview()`에서 `editLocalStorage()` 으로 변경